### PR TITLE
Fix build on Debian

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ all:		mandown
 # executables
 
 mandown:	$(MANDOWN_SRC)
-	$(CC) $(LDFLAGS) $^ -o $@
+	$(CC) $^ -o $@ $(LDFLAGS)
 
 # perfect hashing
 blender_blocks: parser/blender_blocks.h


### PR DESCRIPTION
The project is not building on my debian machine.

I'm not C developer, but from what I read LDFLAGS should be added _after_ the objects you want to link.