### PR TITLE
Fix linking problem on Gentoo

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ DEPDIR=depends
 #MFLAGS=-fPIC
 
 CFLAGS=-c -g -O3 -fPIC -Wall -Wsign-compare -Iparser -Iblender -Iinclude -I/usr/include/libxml2
-LDFLAGS=-g -O3 -lncursesw -lxml2 -Wall -Werror
+LDFLAGS=-g -O3 -Wl,--copy-dt-needed-entries -lncursesw -lxml2 -Wall -Werror
 CC=gcc
 
 MANDOWN_SRC=\


### PR DESCRIPTION
on my system make emitted following error:
`
    /usr/lib/gcc/x86_64-pc-linux-gnu/9.3.0/../../../../x86_64-pc-linux-gnu/bin/ld: src/view.o: undefined reference to symbol 'keypad'
    /usr/lib/gcc/x86_64-pc-linux-gnu/9.3.0/../../../../x86_64-pc-linux-gnu/bin/ld: /lib64/libtinfow.so.6: error adding symbols: DSO missing from command line
`

fixed that with "-Wl,--copy-dt-needed-entries"