### PR TITLE
Change ncurses.h includes to be able to build on arch linux

### DIFF
--- a/include/view.h
+++ b/include/view.h
@@ -1,6 +1,6 @@
 #include <libxml/parser.h>
 #include <libxml/tree.h>
-#include <ncursesw/ncurses.h>
+#include <ncurses.h>
 
 #include "buffer.h"
 

--- a/src/view.c
+++ b/src/view.c
@@ -3,7 +3,7 @@
 #include <libxml/parser.h>
 #include <libxml/tree.h>
 #include <locale.h>
-#include <ncursesw/ncurses.h>
+#include <ncurses.h>
 #include <stdio.h>
 
 #include "buffer.h"


### PR DESCRIPTION
When trying to build the project on arch linux this error occured:

`gcc -c -g -O3 -fPIC -Wall -Wsign-compare -Iparser -Iblender -Iinclude -I/usr/include/libxml2   -c -o src/mandown.o src/mandown.c
In file included from src/mandown.c:12:
include/view.h:3:10: fatal error: ncursesw/ncurses.h: No such file or directory
    3 | #include <ncursesw/ncurses.h>
      |          ^~~~~~~~~~~~~~~~~~~~
compilation terminated.
make: *** [<builtin>: src/mandown.o] Error 1`

Replacing `#include <ncursesw/ncurses.h>` with `#include <ncurses.h>` fixed this problem. I dont know whether this breaks the build process on other systems. I successfully built with these changes on Raspbian.
