### PR TITLE
Make the "include" in xml2 respect the prefix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,7 @@ ifeq ($(UNAME_S),Darwin)
 endif
 
 LDLIB = -l$(CURSES) -lxml2
-CFLAGS = -c -g -O3 -Wall -Wsign-compare -Iparser -Iblender -I/usr/include/libxml2 $(DEFINE)
+CFLAGS = -c -g -O3 -Wall -Wsign-compare -Iparser -Iblender -I$(PREFIX)/include/libxml2 $(DEFINE)
 LDFLAGS = -g -O3 $(OSFLAGS) -Wall -Werror
 # CC = gcc
 


### PR DESCRIPTION
This is an issue in macOS since brew for example puts the header files into `/usr/local` I think the -I should include the prefix so we dont have issues it also uses the path you added as a fallback so there is no important issues.