### PR TITLE
Mandown is now available in brew!

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,11 +75,17 @@ Mandown requires `libncurses(w)` and `libxml2` as compile-time dependencies.
 Make sure you have them installed before compiling.
 
 ### Homebrew
+**From source**
 
 ```shell
 $ brew install ncurses
 $ brew install libxml2-dev
 ```
+**Precompiled binary**
+```shell
+$ brew install mandown
+```
+
 
 ### Debian
 


### PR DESCRIPTION
Mandown is now available in Brew, macOS users can now get it with just a command.

I am working into packaging it for other operating systems.

Amazing project!