### PR TITLE
Update build system and add f/b keys

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 .vscode/
-*.o
 mandown
 test/
-depends/
+build/
 mdn

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@
 
 # Copyright (c) 2009, Natacha Porté
 # Copyright (c) 2019, Tianze Han
+# Copyright (c) 2020, Emil Renner Berthing
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -20,81 +21,116 @@
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
-DEPDIR=depends
 
-# "Machine-dependant" options
-#MFLAGS=-fPIC
+MAKEFLAGS += -rR
+
+TARGET = mdn
+O = build
+
 UNAME_S := $(shell uname -s 2>/dev/null || echo not)
 
-SOURCES = $(sort $(wildcard src/*.c blender/*.c parser/*.c))
-OBJECTS = $(SOURCES:.c=.o)
 PREFIX ?= /usr/local
-TARGET = mdn
 DESTDIR =
 
-CURSES = ncursesw
-OSFLAGS = -Wl,--copy-dt-needed-entries
-DEFINE = -D HAS_NCURSESW_H
+# autoconf compatible variables
+prefix      = $(PREFIX)
+exec_prefix = $(prefix)
+bindir      = $(exec_prefix)/bin
 
+# tools
+CC         = gcc -std=gnu11
+LD         = gcc
+GPERF      = gperf
+MKDIR_P    = mkdir -p
+RM_RF      = rm -rf
+INSTALL    = install
+# use make PKG_CONFIG=pkg-config to use pkg-config
+#PKG_CONFIG = pkg-config
+
+# flags
+OPT       = -O3
+DBGSYMS   = -g
+WARNINGS  = -Wall -Wextra -Wpointer-arith -Wundef -Wno-unused-parameter
+DEPENDS   = -MMD -MP
+INCLUDES  = -Iparser -Iblender
+DEFINES   =
+CFLAGS    = $(OPT) -pipe $(DBGSYMS) $(WARNINGS) $(DEPENDS) $(INCLUDES) $(DEFINES)
+CFLAGS   += $(NCURSES_CFLAGS) $(XML2_CFLAGS)
+LDFLAGS   = $(OPT) $(DBGSYMS)
+LIBS      = $(NCURSES_LIBS) $(XML2_LIBS)
+
+# OS-specific additions
 ifeq ($(UNAME_S),Darwin)
-	CURSES := ncurses
-	OSFLAGS :=
-	DEFINE := -D HAS_NCURSES_H
+NCURSES   = ncurses
+DEFINES  += -D HAS_NCURSES_H
+else
+NCURSES   = ncursesw
+DEFINES  += -D HAS_NCURSESW_H
+LDFLAGS  += -Wl,--copy-dt-needed-entries
 endif
 
-LDLIB = -l$(CURSES) -lxml2
-CFLAGS = -c -g -O3 -Wall -Wsign-compare -Iparser -Iblender -I/usr/include/libxml2 $(DEFINE)
-LDFLAGS = -g -O3 $(OSFLAGS) -Wall -Werror
-# CC = gcc
+# libraries
+NCURSES_CFLAGS := $(if $(PKG_CONFIG),$(shell $(PKG_CONFIG) --cflags $(NCURSES)))
+NCURSES_LIBS   := $(if $(PKG_CONFIG),$(shell $(PKG_CONFIG) --libs $(NCURSES)),-l$(NCURSES))
 
-SRC=\
-	src/mandown.o \
-	src/view.o \
-	src/dom.o \
-	parser/markdown.o \
-	parser/stack.o \
-	parser/buffer.o \
-	parser/autolink.o \
-	blender/blender.o \
-	blender/houdini_blender_e.o \
-	blender/houdini_href_e.o
+XML2            = libxml-2.0
+XML2_CFLAGS    := $(if $(PKG_CONFIG),$(shell $(PKG_CONFIG) --cflags $(XML2)),-I/usr/include/libxml2)
+XML2_LIBS      := $(if $(PKG_CONFIG),$(shell $(PKG_CONFIG) --libs $(XML2)),-lxml2)
 
-all:		$(TARGET)
+# sources
+SOURCES := $(sort $(wildcard src/*.c blender/*.c parser/*.c))
+OBJECTS  = $(SOURCES:%.c=$O/%.o)
 
-.PHONY:		all clean install uninstall
+# use make V=1 to see the raw commands or make -s for silence
+ifeq (,$V$(findstring s,$(word 1,$(MAKEFLAGS))))
+E := @echo
+Q := @
+else
+E := @:
+Q :=
+endif
+
+.SECONDEXPANSION:
+.PRECIOUS: $O/%/ $O/%
+.PHONY: all clean install uninstall
+
+all: $(TARGET)
 
 # executables
-
-$(TARGET):	$(SRC)
-	$(CC) $^ -o $@ $(LDLIB) $(LDFLAGS)
-
+$(TARGET): $(OBJECTS)
+	$E '  LD    $@'
+	$Q$(LD) -o $@ $(LDFLAGS) $^ $(LIBS)
 
 # perfect hashing
 blender_blocks: parser/blender_blocks.h
 
 parser/blender_blocks.h: blender_block_names.txt
-	gperf -N find_block_tag -H hash_block_tag -C -c -E --ignore-case $^ > $@
+	$E '  GPERF $@'
+	$Q$(GPERF) -N find_block_tag -H hash_block_tag -C -c -E --ignore-case $^ > $@
 
+$O/parser/markdown.o: parser/blender_blocks.h
 
 # housekeeping
 clean:
-	$(RM) $(TARGET)
-	$(RM) $(OBJECTS)
+	$E '  RM    $O $(TARGET)'
+	$Q$(RM_RF) $O $(TARGET)
 
-install: all
-	install -d $(DESTDIR)$(PREFIX)/bin
-	install -m 755 $(TARGET) $(DESTDIR)$(PREFIX)/bin/$(TARGET)
+install: $(TARGET)
+	$(INSTALL) -dm755 $(DESTDIR)$(bindir)
+	$(INSTALL) -m755 $(TARGET) $(DESTDIR)$(bindir)/$(TARGET)
 
 uninstall:
-	$(RM) $(DESTDIR)$(PREFIX)/bin/$(TARGET)
+	$(RM_RF) $(DESTDIR)$(bindir)/$(TARGET)
 
-# dependencies
-include $(wildcard $(DEPDIR)/*.d)
-
+# automatic dependencies
+-include $O/*.d $O/*/*.d
 
 # generic object compilations
-%.o:	src/%.c parser/%.c blender/%.c
-	@mkdir -p $(DEPDIR)
-	@$(CC) -MM $< > $(DEPDIR)/$*.d
-	$(CC) $(CFLAGS) -o $@ $<
+$O/%.o:	%.c | $$(@D)/
+	$E '  CC    $<'
+	$Q$(CC) -o $@ $(CFLAGS) -c $<
 
+# generic build directory creation
+$O/%/:
+	$E '  MKDIR $@'
+	$Q$(MKDIR_P) $@

--- a/Makefile
+++ b/Makefile
@@ -62,10 +62,8 @@ LIBS      = $(NCURSES_LIBS) $(XML2_LIBS)
 # OS-specific additions
 ifeq ($(UNAME_S),Darwin)
 NCURSES   = ncurses
-DEFINES  += -D HAS_NCURSES_H
 else
 NCURSES   = ncursesw
-DEFINES  += -D HAS_NCURSESW_H
 LDFLAGS  += -Wl,--copy-dt-needed-entries
 endif
 

--- a/README.md
+++ b/README.md
@@ -58,9 +58,9 @@ Scroll Up: <kbd>↑</kbd>, <kbd>k</kbd>
 
 Scroll Down: <kbd>↓</kbd>, <kbd>j</kbd>
 
-Page Up: <kbd>space bar</kbd>,  <kbd>pg up</kbd>, <kbd>fn + ↑</kbd>
+Page Up: <kbd>space bar</kbd>,  <kbd>pg up</kbd>, <kbd>fn + ↑</kbd>a, <kbd>b</kbd>
 
-Page Down:  <kbd>back space</kbd>,  <kbd>pg down</kbd>, <kbd>fn + ↓</kbd>
+Page Down:  <kbd>back space</kbd>,  <kbd>pg down</kbd>, <kbd>fn + ↓</kbd>, <kbd>f</kbd>
 
 Select & Get href: <kbd>tab</kbd> & <kbd>enter</kbd>
 

--- a/src/st_curses.h
+++ b/src/st_curses.h
@@ -1,4 +1,4 @@
-#ifdef HAS_NCURSES_H
+#if __has_include(<ncurses.h>)
 #include <ncurses.h>
 #else
 #include <ncursesw/ncurses.h>

--- a/src/view.c
+++ b/src/view.c
@@ -498,6 +498,7 @@ int view(const struct config *config, const struct buf *ob, int href_count)
       }
 
       case ' ':
+      case 'f':
       case KEY_NPAGE: {
         if (page->cur_y + ((height - 1) << 1) < page->height)
           page->cur_y += (height - 1);
@@ -507,6 +508,7 @@ int view(const struct config *config, const struct buf *ob, int href_count)
       }
 
       case KEY_BACKSPACE:
+      case 'b':
       case KEY_PPAGE: {
         if (page->cur_y - (height - 1) > 0)
           page->cur_y -= (height - 1);


### PR DESCRIPTION
Hi, nice little tool!

I've updated the Makefile so it should hopefully be a little more flexible for distro maintainers to use pkg-config and overwrite variables with make VAR=whatever.

I've tested it with and without pkg-config on buster, sid, focal, rawhide and Archlinux, but unfortunately I don't have access to a Mac so please test that before merging. Plain `make` should work exactly as before though.