### PR TITLE
fix bug where whitespace after a codespan would be ignored

### DIFF
--- a/parser/markdown.c
+++ b/parser/markdown.c
@@ -656,7 +656,14 @@ char_codespan(struct buf *ob, struct sd_markdown *rndr, uint8_t *data, size_t of
 	/* finding the next delimiter */
 	i = 0;
 	for (end = nb; end < size && i < nb; end++) {
-		if (data[end] == '`') i++;
+		if (data[end] == '`') { 
+			if (end + nb < size && data[end+nb] == ' ') {
+				data[end] = data[end+nb];
+				data[end+nb] = '`';
+				end++;
+			}
+			i++;
+		}
 		else i = 0;
 	}
 
@@ -669,7 +676,7 @@ char_codespan(struct buf *ob, struct sd_markdown *rndr, uint8_t *data, size_t of
 		f_begin++;
 
 	f_end = end - nb;
-	while (f_end > nb && data[f_end-1] == ' ')
+	while (f_end > nb && data[f_end] == ' ')
 		f_end--;
 
 	/* real code span */


### PR DESCRIPTION
Fixes a small bug in which a space immediately following a codespan would be dropped from mandown's output. This PR is admittedly not the most elegant piece of code but it fixes it pretty well by making `markdown.c`'s static `char_codespan()` function check to see if a space immediately follows the code span, and if so moves the space into the code span.

Before:
![image](https://user-images.githubusercontent.com/91640048/215231919-1efcf432-42bc-42cc-ba4f-80d27dd05496.png)
After:
![image](https://user-images.githubusercontent.com/91640048/215231955-2965eff0-855e-4b80-87a8-49aaddf32dbb.png)

No changes where made to the output of mandown on the sample document.